### PR TITLE
Support for returning all the keystore entries

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -83,6 +83,8 @@ This is way you can refer to the same keystore but use a different alias each ti
 
 However, you can choose for only a `password` property be returned with `quarkus.file.vault.set-alias-as-user=false`. In this case you will need to configure a username with the extension specific property, for example, when working with `Agroal` you can use `quarkus.datasource.username`.
 
+Finally, if a keystore alias is not set in `application.properties` (for example, `quarkus.file.vault.provider.db1.alias=quarkus_test`) and is not encoded in the credentials provider name (for example, `quarkus.datasource.credentials-provider=quarkus.file.vault.provider.db1.quarkus_test`) then the provider will return all the keystore entries.
+
 == Protecting the keystore passwords.
 
 If you need to avoid setting a keystore password in `application.properties` then you can use a custom `ConfigSource`, for example:
@@ -122,6 +124,9 @@ add `org.eclipse.microprofile.config.spi.ConfigSource` service provider entry li
 quarkus.file.vault.provider.db1.path=dbpasswords.p12
 quarkus.file.vault.provider.db1.secret=${db1.storepassword}
 ----
+
+Please note that in this example, hardcoding a keystore password such as `db1.storepassword` in `KeyStoreConfigSource` is only done to simplify the documentation.
+In real world applications, custom `ConfigSource` implementations will read it from a DB or other secure storage.
 
 == Using FileVaultCredentialsProvider directly
 

--- a/runtime/src/test/java/io/quarkiverse/filevault/runtime/FileVaultCredentialsProviderTest.java
+++ b/runtime/src/test/java/io/quarkiverse/filevault/runtime/FileVaultCredentialsProviderTest.java
@@ -35,6 +35,15 @@ public class FileVaultCredentialsProviderTest {
     }
 
     @Test
+    public void testGetAllCredentials() throws Exception {
+        CredentialsProvider cp = createCredentialsProvider(false, false);
+        Map<String, String> creds = cp.getCredentials(FileVaultCredentialsProvider.BASE_PROVIDER_NAME + "." + PROVIDER_NAME);
+        assertEquals(2, creds.size());
+        assertEquals(STORED_PASSWORD, creds.get(KEY_ALIAS));
+        verifyCertificate(creds.get(CERTIFICATE_ALIAS));
+    }
+
+    @Test
     public void testGetPasswordOnly() throws Exception {
         CredentialsProvider cp = createCredentialsProvider(true, false);
         Map<String, String> creds = cp.getCredentials(FileVaultCredentialsProvider.BASE_PROVIDER_NAME + "." + PROVIDER_NAME);
@@ -74,11 +83,15 @@ public class FileVaultCredentialsProviderTest {
         assertNull(creds.get(CredentialsProvider.USER_PROPERTY_NAME));
         assertNull(creds.get(CredentialsProvider.PASSWORD_PROPERTY_NAME));
 
-        String derEncodedCert = creds.get(FileVaultCredentialsProvider.CERTIFICATE_PROPERTY);
+        verifyCertificate(creds.get(FileVaultCredentialsProvider.CERTIFICATE_PROPERTY));
+    }
+
+    private void verifyCertificate(String derEncodedCert) throws Exception {
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
         X509Certificate cert = (X509Certificate) cf
                 .generateCertificate(new ByteArrayInputStream(derEncodedCert.getBytes(StandardCharsets.ISO_8859_1)));
         assertTrue(cert.getSubjectX500Principal().getName().startsWith("CN=Quarkus,OU=Quarkus,O=Quarkus"));
+
     }
 
     private Map<String, String> createKeystoreProps(boolean includeAlias, boolean isSecretMasked, String secret) {


### PR DESCRIPTION
It is not possible to extract more than one secret at a time from the provider, for example, in case of Quarkus Vert.x HTTP where the keystore, keystore key and truststore passwords may need to be extracted at the same time.

So this PR makes it possible to return all the entries if the alias is not configured. And it drops the default keystore secret (`secret`) and alias (`user`) as they don't really make sense and not really secure. I probably added them initially to avoid doing the extra checks.

@pedro-hos FYI