### PR TITLE
Add missing description to extension

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -8,6 +8,7 @@
   </parent>
   <artifactId>quarkus-file-vault</artifactId>
   <name>Quarkus - File Vault - Runtime</name>
+  <description>Credentials Provider which extracts secrets from Java KeyStore</description>
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
This is necessary to list the proper description from the registry